### PR TITLE
Updated device PL requirement

### DIFF
--- a/pennylane_qiskit/devices.py
+++ b/pennylane_qiskit/devices.py
@@ -100,7 +100,7 @@ QISKIT_OPERATION_MAP = {
 class QiskitDevice(Device):
     name = 'Qiskit PennyLane plugin'
     short_name = 'qiskit'
-    pennylane_requires = '0.1.0'
+    pennylane_requires = '>=0.1.0'
     version = '0.1.0'
     plugin_version = __version__
     author = 'Carsten Blank'


### PR DESCRIPTION
This future-proofs the Qiskit plugin, by allowing the device to work with all new versions of PennyLane.