### PR TITLE
Multiple keywords fix

### DIFF
--- a/pennylane_qiskit/devices.py
+++ b/pennylane_qiskit/devices.py
@@ -258,8 +258,7 @@ class LegacySimulatorsQiskitDevice(QiskitDevice):
     """
     short_name = 'qiskit.legacy'
 
-    def __init__(self, wires, shots=1024, **kwargs):
-        backend = kwargs.get('backend', 'qasm_simulator')
+    def __init__(self, wires, shots=1024, backend='qasm_simulator', **kwargs):
         super().__init__(wires, backend=backend, shots=shots, **kwargs)
         self._provider = qiskit.LegacySimulators
         self._capabilities['backend'] = [b.name() for b in self._provider.backends()]
@@ -310,8 +309,7 @@ class BasicAerQiskitDevice(QiskitDevice):
     """
     short_name = 'qiskit.basicaer'
 
-    def __init__(self, wires, shots=1024, **kwargs):
-        backend = kwargs.get('backend', 'qasm_simulator')
+    def __init__(self, wires, shots=1024, backend='qasm_simulator', **kwargs):
         super().__init__(wires, backend=backend, shots=shots, **kwargs)
         self._provider = qiskit.BasicAer
         self._capabilities['backend'] = [b.name() for b in self._provider.backends()]
@@ -362,8 +360,7 @@ class AerQiskitDevice(QiskitDevice):
     """
     short_name = 'qiskit.basicaer'
 
-    def __init__(self, wires, shots=1024, **kwargs):
-        backend = kwargs.get('backend', 'qasm_simulator')
+    def __init__(self, wires, shots=1024, backend='qasm_simulator', **kwargs):
         super().__init__(wires, backend=backend, shots=shots, **kwargs)
         self._provider = qiskit.Aer
         self._capabilities['backend'] = [b.name() for b in self._provider.backends()]

--- a/pennylane_qiskit/devices.py
+++ b/pennylane_qiskit/devices.py
@@ -183,7 +183,7 @@ class QiskitDevice(Device):
         try:
             self._current_job = backend.run(qobj)  # type: BaseJob
             not_done = [JobStatus.INITIALIZING, JobStatus.QUEUED, JobStatus.RUNNING, JobStatus.VALIDATING]
-            self._current_job.result() #call result here once and discard it to trigger the actual computation
+            self._current_job.result()  # call result here once and discard it to trigger the actual computation
 
         except Exception as ex:
             raise Exception("Error during job execution: {}!".format(ex))

--- a/pennylane_qiskit/devices.py
+++ b/pennylane_qiskit/devices.py
@@ -415,13 +415,12 @@ class IbmQQiskitDevice(QiskitDevice):
     short_name = 'qiskit.ibmq'
     _backend_kwargs = ['verbose', 'backend', 'ibmqx_token']
 
-    def __init__(self, wires, shots=1024, **kwargs):
+    def __init__(self, wires, backend='ibmq_qasm_simulator', shots=1024, **kwargs):
         token_from_env = os.getenv('IBMQX_TOKEN')
         if 'ibmqx_token' not in kwargs and token_from_env is None:
             raise ValueError("IBMQX Token is missing!")
         token = token_from_env or kwargs['ibmqx_token']
-        backend = kwargs.get('backend', 'ibmq_qasm_simulator')
-        super().__init__(wires, backend=backend, shots=shots, **kwargs)
+        super().__init__(wires=wires, backend=backend, shots=shots, **kwargs)
         self._provider = qiskit.IBMQ
         if token not in map(lambda e: e['token'], self._provider.active_accounts()):
             self._provider.enable_account(token)

--- a/tests/test_device_initialization.py
+++ b/tests/test_device_initialization.py
@@ -19,7 +19,7 @@ import logging as log
 import os
 import unittest
 
-from pennylane import DeviceError
+from pennylane import DeviceError, Device
 
 from defaults import pennylane as qml, BaseTest, IBMQX_TOKEN
 from pennylane_qiskit import IbmQQiskitDevice
@@ -55,7 +55,6 @@ class DeviceInitialization(BaseTest):
             dev1 = IbmQQiskitDevice(wires=self.num_subsystems, shots=shots, ibmqx_token=IBMQX_TOKEN)
             self.assertEqual(shots, dev1.shots)
 
-
     def test_initiatlization_via_pennylane(self):
         for short_name in [
                 'qiskit.aer',
@@ -65,6 +64,36 @@ class DeviceInitialization(BaseTest):
         ]:
             try:
                 qml.device(short_name, wires=2, ibmqx_token=IBMQX_TOKEN)
+            except DeviceError:
+                raise Exception("This test is expected to fail until pennylane-qiskit is installed.")
+
+    def test_ibm_device(self):
+        if self.args.provider in ['ibm', 'all']:
+            import qiskit
+            qiskit.IBMQ.enable_account(token=IBMQX_TOKEN)
+            backends = qiskit.IBMQ.backends()
+            qiskit.IBMQ.disable_accounts()
+            try:
+                for backend in backends:
+                    qml.device('qiskit.ibm', wires=1, ibmqx_token=IBMQX_TOKEN, backend=backend)
+            except DeviceError:
+                raise Exception("This test is expected to fail until pennylane-qiskit is installed.")
+
+    def test_aer_device(self):
+        if self.args.provider in ['aer', 'all']:
+            import qiskit
+            try:
+                for backend in qiskit.Aer.backends():
+                    qml.device('qiskit.aer', wires=1, backend=backend)
+            except DeviceError:
+                raise Exception("This test is expected to fail until pennylane-qiskit is installed.")
+
+    def test_basicaer_device(self):
+        if self.args.provider in ['aer', 'all']:
+            import qiskit
+            try:
+                for backend in qiskit.BasicAer.backends():
+                    qml.device('qiskit.basicaer', wires=1, backend=backend)
             except DeviceError:
                 raise Exception("This test is expected to fail until pennylane-qiskit is installed.")
 


### PR DESCRIPTION
Regarding Issue #13 this is my suggestion to fix the bug:

make the arguments `backend` and `shots` on the `__init__` function explicit so that there cannot be any duplicates on the dict `kwargs`.

Changes have been done on the file `devices.py` and tests have been added to `test_device_initialization.py`.