### PR TITLE
Modify custom ops to have correct parameter domains

### DIFF
--- a/pennylane_qiskit/ops.py
+++ b/pennylane_qiskit/ops.py
@@ -84,7 +84,7 @@ class U1(Operation):
     """
     num_params = 1
     num_wires = 1
-    par_domain = None
+    par_domain = 'R'
 
 
 class U2(Operation):
@@ -100,7 +100,7 @@ class U2(Operation):
     """
     num_params = 2
     num_wires = 1
-    par_domain = None
+    par_domain = 'R'
 
 
 class U3(Operation):
@@ -117,4 +117,4 @@ class U3(Operation):
     """
     num_params = 3
     num_wires = 1
-    par_domain = None
+    par_domain = 'R'


### PR DESCRIPTION
Currently, the custom operations `U1`, `U2`, and `U3` can not be imported by PennyLane, as they accept parameters but the par domain is set to `None` (resulting in the exception `
ValueError: U3: Unknown parameter domain 'None'.`).

This small PR addresses this, updating their parameter domain such that
```python
par_domain = 'R'
```
i.e., all parameters for these gates are real.