### PR TITLE
Update/qiskit0.8.0

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -19,9 +19,24 @@ The format is based on `Keep a Changelog`_.
 `UNRELEASED`_
 =============
 
-Changed
--------
 
+`0.0.5`_ - `0.0.6`
+===================
+
+Added
+------
+
+- Added the noise model to ``BasicAerQiskitDevice`` and ``AerQiskitDevice`` with unit tests (#13)
+- Added unit tests for the docs (#7/#20)
+
+Fixed
+------
+
+- Fixed the ''multiple'' ``backends`` keyword bug (#13).
+- Fixed the ``par_domain`` of the operations (real valued parameters) in ``pos.py`` (#21)
+- Fixed documentation problems
+- Started to 'fix' ''low'' code quality due to type hints with codacy (#15)
+- Small typos and code cleanups
 
 `0.0.2`_ - 2018-12-23
 ======================

--- a/README.rst
+++ b/README.rst
@@ -175,7 +175,7 @@ We also encourage bug reports, suggestions for new features and enhancements, an
 Authors
 =======
 
-Carsten Blank, Sebastian Boerakker
+Carsten Blank, Sebastian Boerakker, Christian Gogolin, Josh Izaac
 
 .. support-start-inclusion-marker-do-not-remove
 

--- a/pennylane_qiskit/_version.py
+++ b/pennylane_qiskit/_version.py
@@ -16,4 +16,4 @@
    Version number (major.minor.patch[-label])
 """
 
-__version__ = '0.0.5'
+__version__ = '0.0.6'

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-qiskit>=0.7.0,<0.8.0
+qiskit>=0.8.0,<0.9.0
 PennyLane


### PR DESCRIPTION
This PR includes the update to qiskit 0.8.0 (which is still qiskit-terra 0.7.x -- brace yourself for 0.8.0!!) and also includes updates to the list of authors, updated changelog (yes I know, it still sucks!) as well as noise model, bug fixes more unit tests.