### PR TITLE
Fixes the expectation map

### DIFF
--- a/pennylane_qiskit/devices.py
+++ b/pennylane_qiskit/devices.py
@@ -106,8 +106,7 @@ class QiskitDevice(Device):
         'model': 'qubit'
     }  # type: Dict[str, any]
     _operation_map = QISKIT_OPERATION_MAP
-    _expectation_map = {key: val for key, val in _operation_map.items()
-                        if val in [x, y, z]}
+    _expectations = {'PauliZ'}
     _backend_kwargs = ['verbose', 'backend']
 
     def __init__(self, wires, backend, shots=1024, **kwargs):
@@ -137,7 +136,7 @@ class QiskitDevice(Device):
 
     @property
     def expectations(self):
-        return set(self._expectation_map.keys())
+        return set(self._expectations)
 
     def apply(self, operation, wires, par):
         # type: (Any, Sequence[int], List) -> None


### PR DESCRIPTION
Previously, the way `_expectation_map` was defined was resulting in an empty set. This was breaking the ability of PennyLane to do expectation validation before sending the qnode to simulation. For example,
```python
import pennylane as qml

dev = qml.device('qiskit.basicaer', wires=2)

@qml.qnode(dev)
def circuit(x):
    qml.RX(x, wires=0)
    return qml.expval.PauliX(0)

print(circuit(0.43))
```
gives the obfuscated error
```
  File "pennylane/pennylane/qnode.py", line 513, in evaluate
    return self.output_type(ret)
TypeError: float() argument must be a string or a number, not 'NoneType'
```

Here, I have replaced the `_expectation_map` with an explicit set `_expectations = {'PauliZ'}`. Running the above example above, now gives the more useful error
```
pennylane._device.DeviceError: Expectation PauliX not supported on device qiskit.basicaer
```