### PR TITLE
Fix/after expectation fix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,5 +18,7 @@ install:
   - pip install dist/PennyLane*.whl
 script:
   - make coverage
+  - 'if [ "$TRAVIS_PULL_REQUEST" != "false" ]; then make coverage-aer; fi'
+  - 'if [ "$TRAVIS_PULL_REQUEST" = "false" ]; then make coverage; fi'
 after_success:
   - codecov

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,6 @@ install:
   - python setup.py bdist_wheel
   - pip install dist/PennyLane*.whl
 script:
-  - make coverage
   - 'if [ "$TRAVIS_PULL_REQUEST" != "false" ]; then make coverage-aer; fi'
   - 'if [ "$TRAVIS_PULL_REQUEST" = "false" ]; then make coverage; fi'
 after_success:

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -19,6 +19,17 @@ The format is based on `Keep a Changelog`_.
 `UNRELEASED`_
 =============
 
+Changed
+--------
+
+- Renamed the IBMQ device from :code:`qiskit.ibm` to :code:`qiskit.ibmq`
+
+Fixed
+------
+
+- Fixed the valid expectation values of all devices. Along with it tests where fixed.
+
+
 
 `0.0.5`_ - `0.0.6`
 ===================

--- a/README.rst
+++ b/README.rst
@@ -40,7 +40,7 @@ This PennyLane plugin allows to use both the software and hardware backends of q
 Features
 ========
 
-* Provides two providers to be used with PennyLane: ``qiskit.basicaer`` and ``qiskit.ibm``. These provide access to the respective qiskit backends.
+* Provides two providers to be used with PennyLane: ``qiskit.basicaer`` and ``qiskit.ibmq``. These provide access to the respective qiskit backends.
 
 * Supports a wide range of PennyLane operations and expectation values across the providers.
 
@@ -65,14 +65,14 @@ To test that the PennyLane qiskit plugin is working correctly you can run
 
     $ make test
 
-in the source folder. Tests restricted to a specific provider can be run by executing :code:`make test-aer` or :code:`make test-ibm`.
+in the source folder. Tests restricted to a specific provider can be run by executing :code:`make test-aer` or :code:`make test-ibmq`.
 
 .. note::
     Tests on the `ibm provider <https://pennylane-qiskit.readthedocs.io/en/latest/devices.html>`_ can
     only be run if a :code:`ibmqx_token` for the `IBM Q experience <https://quantumexperience.ng.bluemix.net/qx/experience>`_ is
     configured in the `PennyLane configuration file <https://pennylane.readthedocs.io/configuration.html>`_.
-    If this is the case, running :code:`make test` also executes tests on the :code:`ibm` provider. By default tests on
-    the :code:`ibm` provider run with :code:`ibmq_qasm_simulator` backend and those done by the :code:`basicaer` provider are
+    If this is the case, running :code:`make test` also executes tests on the :code:`ibmq` provider. By default tests on
+    the :code:`ibmq` provider run with :code:`ibmq_qasm_simulator` backend and those done by the :code:`basicaer` provider are
     run with the :code:`qasm_simulator` backend. At the time of writing this means that the test are "free".
     Please verify that this is also the case for your account.
 .. installation-end-inclusion-marker-do-not-remove
@@ -121,12 +121,12 @@ To get a current overview what backends are available you can query this by
     dev.capabilities()['backend']
 
 Running your code on an IBM Quantum Experience simulator or even a real hardware chip is just as easy. Instead of the
-device above, you would instantiate a :code:`'qiskit.ibm'` device by giving your IBM Quantum Experience token:
+device above, you would instantiate a :code:`'qiskit.ibmq'` device by giving your IBM Quantum Experience token:
 
 .. code-block:: python
 
     import pennylane as qml
-    dev = qml.device('qiskit.ibm', wires=2, ibmqx_token="XXX")
+    dev = qml.device('qiskit.ibmq', wires=2, ibmqx_token="XXX")
 
 In order to avoid accidentally publishing your token, you should better specify it via the `PennyLane configuration file <https://pennylane.readthedocs.io/en/latest/code/configuration.html>`__ by adding a section such as
 
@@ -134,12 +134,12 @@ In order to avoid accidentally publishing your token, you should better specify 
 
   [qiskit.global]
 
-    [qiskit.ibm]
+    [qiskit.ibmq]
     ibmqx_token = "XXX"
 
 It is also possible to define an environment variable :code:`IBMQX_TOKEN`, from which the token will be taken if not provided in another way.
 
-Per default the backend :code:`ibm` uses the simulator backend :code:`ibmq_qasm_simulator`, but you can change that
+Per default the backend :code:`ibmq` uses the simulator backend :code:`ibmq_qasm_simulator`, but you can change that
 to be any of the real backends as given by
 
 .. code-block:: python

--- a/doc/tutorials.rst
+++ b/doc/tutorials.rst
@@ -10,4 +10,4 @@ from the documentation of PennyLane and run them on a ``'qiskit.aer'`` device by
 
 for an appropriate number of wires.
 
-You can also try to run, e.g., the qubit rotation code on actual quantum hardware by using the ``'qiskit.ibm'`` device.
+You can also try to run, e.g., the qubit rotation code on actual quantum hardware by using the ``'qiskit.ibmq'`` device.

--- a/pennylane_qiskit/devices.py
+++ b/pennylane_qiskit/devices.py
@@ -45,6 +45,7 @@ IbmQQiskitDevice
 .. autoclass:: IbmQQiskitDevice
 
 """
+import inspect
 import os
 from typing import Dict, Sequence, Any, List, Union, Optional, Type
 

--- a/pennylane_qiskit/devices.py
+++ b/pennylane_qiskit/devices.py
@@ -252,7 +252,7 @@ class BasicAerQiskitDevice(QiskitDevice):
       :class:`pennylane.BasisState`
 
     Supported PennyLane Expectations:
-      :class:`pennylane.PauliZ`
+      :class:`pennylane.expval.PauliZ`
 
     Extra Operations:
       :class:`pennylane_qiskit.S <pennylane_qiskit.ops.S>`,
@@ -306,7 +306,7 @@ class AerQiskitDevice(QiskitDevice):
       :class:`pennylane.BasisState`
 
     Supported PennyLane Expectations:
-      :class:`pennylane.PauliZ`
+      :class:`pennylane.expval.PauliZ`
 
     Extra Operations:
       :class:`pennylane_qiskit.S <pennylane_qiskit.ops.S>`,
@@ -360,7 +360,7 @@ class IbmQQiskitDevice(QiskitDevice):
       :class:`pennylane.BasisState`
 
     Supported PennyLane Expectations:
-      :class:`pennylane.PauliZ`
+      :class:`pennylane.expval.PauliZ`
 
     Extra Operations:
       :class:`pennylane_qiskit.S <pennylane_qiskit.ops.S>`,

--- a/pennylane_qiskit/devices.py
+++ b/pennylane_qiskit/devices.py
@@ -327,7 +327,7 @@ class AerQiskitDevice(QiskitDevice):
 
 
 class IbmQQiskitDevice(QiskitDevice):
-    """A PennyLane :code:`qiskit.ibm` device for the `Qiskit Local Simulator` backend.
+    """A PennyLane :code:`qiskit.ibmq` device for the `Qiskit Local Simulator` backend.
 
     Args:
        wires (int): The number of qubits of the device

--- a/pennylane_qiskit/devices.py
+++ b/pennylane_qiskit/devices.py
@@ -187,7 +187,6 @@ class QiskitDevice(Device):
             else:
                 self._current_job = backend.run(qobj)  # type: BaseJob
 
-            not_done = [JobStatus.INITIALIZING, JobStatus.QUEUED, JobStatus.RUNNING, JobStatus.VALIDATING]
             self._current_job.result()  # call result here once and discard it to trigger the actual computation
 
         except Exception as ex:

--- a/pennylane_qiskit/devices.py
+++ b/pennylane_qiskit/devices.py
@@ -316,7 +316,7 @@ class AerQiskitDevice(QiskitDevice):
       :class:`pennylane_qiskit.U3 <pennylane_qiskit.ops.U3>`,
 
     """
-    short_name = 'qiskit.basicaer'
+    short_name = 'qiskit.aer'
 
     def __init__(self, wires, shots=1024, backend='qasm_simulator', noise_model=None, **kwargs):
         super().__init__(wires, backend=backend, shots=shots, **kwargs)

--- a/pennylane_qiskit/devices.py
+++ b/pennylane_qiskit/devices.py
@@ -46,20 +46,18 @@ IbmQQiskitDevice
 
 """
 import os
-import inspect
 from typing import Dict, Sequence, Any, List, Union, Optional, Type
 
 import qiskit
 import qiskit.compiler
 from pennylane import Device, DeviceError
 from qiskit import QuantumRegister, ClassicalRegister, QuantumCircuit
-from qiskit.circuit import Instruction, Gate
+from qiskit.circuit import Gate
 from qiskit.circuit.measure import measure
 from qiskit.converters import dag_to_circuit, circuit_to_dag
 from qiskit.extensions import XGate, RXGate, U1Gate, HGate, RYGate, RZGate, CzGate, CnotGate, YGate, ZGate, SGate, \
     TGate, U2Gate, U3Gate, SwapGate
-from qiskit.extensions.standard import (x, y, z)
-from qiskit.providers import BaseProvider, BaseJob, BaseBackend, JobStatus
+from qiskit.providers import BaseProvider, BaseJob, BaseBackend
 from qiskit.providers.aer.backends.aerbackend import AerBackend
 from qiskit.result import Result
 

--- a/pennylane_qiskit/qiskitops.py
+++ b/pennylane_qiskit/qiskitops.py
@@ -108,13 +108,16 @@ class QubitUnitary(QiskitInstructions):
         # type: (List[Tuple[QuantumRegister, int]], List, QuantumCircuit) -> None
         if len(param) == 0:
             raise Exception('Parameters are missing')
-        if len(param[0]) != 4:
+        parameters = param[0]
+        if isinstance(parameters, np.ndarray):
+            parameters = parameters.reshape((4,))
+        if len(parameters) != 4:
             raise Exception('An array of 4 complex numbers must be given.')
 
-        a = param[0][0]  # type: complex
-        b = param[0][1]  # type: complex
-        c = param[0][2]  # type: complex
-        d = param[0][3]  # type: complex
+        a = parameters[0]  # type: complex
+        b = parameters[1]  # type: complex
+        c = parameters[2]  # type: complex
+        d = parameters[3]  # type: complex
 
         col1 = math.sqrt(abs(a) ** 2 + abs(c) ** 2)
         col2 = math.sqrt(abs(b) ** 2 + abs(d) ** 2)

--- a/pennylane_qiskit/qiskitops.py
+++ b/pennylane_qiskit/qiskitops.py
@@ -126,7 +126,7 @@ class QubitUnitary(QiskitInstructions):
             raise Exception('Not a unitary.')
 
         global_phase = cmath.phase(a)
-        theta = 2 * acos(a * cmath.exp(-global_phase))
+        theta = 2 * acos(abs(a) * math.exp(-global_phase))
 
         lam = None  # type: Optional[float]
         phi = None  # type: Optional[float]

--- a/pennylane_qiskit/qiskitops.py
+++ b/pennylane_qiskit/qiskitops.py
@@ -25,6 +25,7 @@ import math
 from math import acos
 from typing import List, Tuple, Optional
 
+import numpy as np
 from qiskit import QuantumRegister, QuantumCircuit
 from qiskit.extensions import standard
 from qiskit.extensions.standard import x, rx, ry, rz
@@ -94,6 +95,8 @@ class Rot(QiskitInstructions):
 
 
 class QubitUnitary(QiskitInstructions):
+
+    tolerance = 1e-6
     """Class for the arbitrary single qubit rotation gate.
 
     ProjectQ does not currently have an arbitrary single qubit rotation gate,
@@ -124,9 +127,9 @@ class QubitUnitary(QiskitInstructions):
 
         lam = None  # type: Optional[float]
         phi = None  # type: Optional[float]
-        if abs(b) > 1e-6:
+        if abs(b) > self.tolerance:
             lam = -cmath.phase(b * cmath.exp(-global_phase))
-        if abs(c) > 1e-6:
+        if abs(c) > self.tolerance:
             phi = cmath.phase(c * cmath.exp(-global_phase))
 
         lam_phi = cmath.phase(d * cmath.exp(-global_phase))
@@ -139,7 +142,7 @@ class QubitUnitary(QiskitInstructions):
         elif lam is not None and phi is None:
             phi = lam_phi - lam
 
-        if d != cmath.exp(1.0j * lam + 1.0j * phi) * cmath.cos(theta / 2):
+        if abs(d - cmath.exp(1.0j * lam + 1.0j * phi) * cmath.cos(theta / 2)) > self.tolerance:
             raise Exception('Not a unitary.')
 
         if isinstance(qregs, list):

--- a/pennylane_qiskit/qiskitops.py
+++ b/pennylane_qiskit/qiskitops.py
@@ -170,4 +170,4 @@ class QubitStateVector(QiskitInstructions):
         if len(param) > 2 ** len(qregs):
             raise Exception("Too many parameters for the amount of qubits")
         from qiskit.extensions import initializer
-        initializer.initialize(circuit, param[0], qregs)
+        initializer.initialize(circuit, param[0], list(reversed(qregs)))

--- a/pennylane_qiskit/qiskitops.py
+++ b/pennylane_qiskit/qiskitops.py
@@ -89,7 +89,7 @@ class Rot(QiskitInstructions):
         if len(param) == 0:
             raise Exception('Parameters are missing')
         for q in qregs:
-            rx.rx(circuit, param[0], q)
+            rz.rz(circuit, param[0], q)
             ry.ry(circuit, param[1], q)
             rz.rz(circuit, param[2], q)
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 qiskit>=0.10.1,<0.11.0
 PennyLane
+numpy

--- a/setup.py
+++ b/setup.py
@@ -38,7 +38,7 @@ info = {
         'pennylane.plugins': [
             'qiskit.aer = pennylane_qiskit:AerQiskitDevice',
             'qiskit.basicaer = pennylane_qiskit:BasicAerQiskitDevice',
-            'qiskit.ibm = pennylane_qiskit:IbmQQiskitDevice',
+            'qiskit.ibmq = pennylane_qiskit:IbmQQiskitDevice',
             ],
         },
     'description': 'PennyLane plugin for qiskit-terra',

--- a/tests/defaults.py
+++ b/tests/defaults.py
@@ -17,13 +17,13 @@ sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')
 import pennylane_qiskit  # pylint: disable=wrong-import-position,unused-import
 
 # defaults
-if 'PROVIDER' in os.environ and os.environ['PROVIDER'] is not None:
-    PROVIDER = os.environ['PROVIDER']  # type: str
-    PROVIDER = PROVIDER.lower()
+if 'DEVICE' in os.environ and os.environ['DEVICE'] is not None:
+    DEVICE = os.environ['DEVICE']  # type: str
+    DEVICE = DEVICE.lower()
 else:
-    PROVIDER = "all"
+    DEVICE = "all"
 OPTIMIZER = "GradientDescentOptimizer"
-if PROVIDER == "all" or PROVIDER == "ibm":
+if DEVICE == "all" or DEVICE == "ibmq":
     TOLERANCE = 3e-2
 else:
     TOLERANCE = 3e-2
@@ -57,12 +57,12 @@ def get_commandline_args():
       argparse.Namespace: parsed arguments in a namespace container
     """
     parser = argparse.ArgumentParser()
-    parser.add_argument('-p', '--provider', type=str, default=PROVIDER,
-                        help='Provider(s) to use for tests.', choices=['aer', 'basicaer', 'ibm', 'all'])
+    parser.add_argument('-p', '--device', type=str, default=DEVICE,
+                        help='Device(s) to use for tests.', choices=['aer', 'basicaer', 'ibmq', 'all'])
     parser.add_argument('-t', '--tolerance', type=float, default=TOLERANCE,
                         help='Numerical tolerance for equality tests.')
-    parser.add_argument("--ibmqx_token",
-                        help="IBM Quantum Experience token for use with the provider 'ibm'")
+    parser.add_argument("--ibmqx_token",default=IBMQX_TOKEN,
+                        help="IBM Quantum Experience token for use with the device 'ibmq'")
     parser.add_argument("--optimizer", default=OPTIMIZER, choices=pennylane.optimize.__all__,
                         help="optimizer to use")
 

--- a/tests/defaults.py
+++ b/tests/defaults.py
@@ -44,6 +44,7 @@ else:
     numeric_level = 100
 
 logging.getLogger().setLevel(numeric_level)
+logging.basicConfig(format=logging.BASIC_FORMAT)
 logging.captureWarnings(True)
 
 

--- a/tests/defaults.py
+++ b/tests/defaults.py
@@ -105,6 +105,14 @@ class BaseTest(unittest.TestCase):
             if np.all([np.all(np.abs(first[idx] - second[idx])) <= delta for idx, _ in enumerate(first)]):
                 return
         else:
+            # TODO 2019-06-08 C. Blank this is all a whacky hack...
+            if isinstance(first, float):
+                first = [first]
+            if isinstance(second, float):
+                second = [second]
+
+            first = np.asarray(list(first))
+            second = np.asarray(list(second))
             if np.all(first == second):
                 return
             if np.all(np.abs(first - second) <= delta):

--- a/tests/defaults.py
+++ b/tests/defaults.py
@@ -18,7 +18,8 @@ import pennylane_qiskit  # pylint: disable=wrong-import-position,unused-import
 
 # defaults
 if 'PROVIDER' in os.environ and os.environ['PROVIDER'] is not None:
-    PROVIDER = os.environ['PROVIDER']
+    PROVIDER = os.environ['PROVIDER']  # type: str
+    PROVIDER = PROVIDER.lower()
 else:
     PROVIDER = "all"
 OPTIMIZER = "GradientDescentOptimizer"

--- a/tests/defaults.py
+++ b/tests/defaults.py
@@ -26,7 +26,7 @@ OPTIMIZER = "GradientDescentOptimizer"
 if PROVIDER == "all" or PROVIDER == "ibm":
     TOLERANCE = 3e-2
 else:
-    TOLERANCE = 1e-3
+    TOLERANCE = 3e-2
 
 IBMQX_TOKEN = None
 ibm_options = pennylane.default_config['qiskit.ibm']

--- a/tests/defaults.py
+++ b/tests/defaults.py
@@ -29,7 +29,7 @@ else:
     TOLERANCE = 3e-2
 
 IBMQX_TOKEN = None
-ibm_options = pennylane.default_config['qiskit.ibm']
+ibm_options = pennylane.default_config['qiskit.ibmq']
 if 'ibmqx_token' in ibm_options:
     IBMQX_TOKEN = ibm_options['ibmqx_token']
 elif 'IBMQX_TOKEN' in os.environ and os.environ['IBMQX_TOKEN'] is not None:

--- a/tests/test_basis_state.py
+++ b/tests/test_basis_state.py
@@ -38,11 +38,11 @@ class BasisStateTest(BaseTest):
         super().setUp()
 
         self.devices = []
-        if self.args.provider == 'basicaer' or self.args.provider == 'all':
+        if self.args.device == 'basicaer' or self.args.device == 'all':
             self.devices.append(BasicAerQiskitDevice(wires=self.num_subsystems))
-        if self.args.provider == 'aer' or self.args.provider == 'all':
+        if self.args.device == 'aer' or self.args.device == 'all':
             self.devices.append(AerQiskitDevice(wires=self.num_subsystems))
-        if self.args.provider == 'ibm' or self.args.provider == 'all':
+        if self.args.device == 'ibmq' or self.args.device == 'all':
             if IBMQX_TOKEN is not None:
                 self.devices.append(
                     IbmQQiskitDevice(wires=self.num_subsystems, num_runs=8 * 1024, ibmqx_token=IBMQX_TOKEN))

--- a/tests/test_basis_state.py
+++ b/tests/test_basis_state.py
@@ -66,6 +66,8 @@ class BasisStateTest(BaseTest):
                     qml.BasisState(bits_to_flip, wires=list(range(self.num_subsystems)))
                     return qml.expval.PauliZ(0), qml.expval.PauliZ(1), qml.expval.PauliZ(2), qml.expval.PauliZ(3)
 
+                log.info("BasisState on device %s with bitflip pattern %s.", device.name, bits_to_flip)
+
                 self.assertAllAlmostEqual([1] * self.num_subsystems - 2 * bits_to_flip, np.array(circuit()),
                                           delta=self.tol)
 
@@ -85,6 +87,8 @@ class BasisStateTest(BaseTest):
                 def circuit():
                     qml.BasisState(bits_to_flip, wires=list(range(self.num_subsystems - 1)))
                     return qml.expval.PauliZ(0), qml.expval.PauliZ(1), qml.expval.PauliZ(2), qml.expval.PauliZ(3)
+
+                log.info("BasisState on device %s with bitflip pattern %s (sub-system).", device.name, bits_to_flip)
 
                 self.assertAllAlmostEqual([1] * (self.num_subsystems - 1) - 2 * bits_to_flip, np.array(circuit()[:-1]),
                                           delta=self.tol)

--- a/tests/test_compare_with_default_qubit.py
+++ b/tests/test_compare_with_default_qubit.py
@@ -152,13 +152,15 @@ class CompareWithDefaultQubitTest(BaseTest):
         # if we could run the circuit on more than one device assert that both should have given the same output
         for (key, val) in outputs.items():
             if len(val) >= 2:
-                self.assertAllElementsAlmostEqual(val.values(), delta=self.tol,
-                                                  msg="Outputs {} of devices [{}] do not agree for a "
-                                                      "circuit consisting of a {} Operation followed "
-                                                      "by a {} Expectation.".format(
-                                                      str(list(val.values())), ', '.join(list(val.keys())),
-                                                      str(key[0]), str(key[1])
-                                                  ))
+                failed_message="Outputs {} of devices [{}] do not agree for a " \
+                               "circuit consisting of a {} Operation followed " \
+                               "by a {} Expectation.".format(
+                    str(list(val.values())), ', '.join(list(val.keys())),
+                    str(key[0]), str(key[1]))
+
+                reference_output = val['DefaultQubit(shots=0)']
+                self.assertAllAlmostEqual(val.values(), len(val) * [reference_output], delta=self.tol, msg=failed_message)
+
 
 if __name__ == '__main__':
     log.info('Testing PennyLane qiskit Plugin version ' + qml.version() + ', Device class.')

--- a/tests/test_compare_with_default_qubit.py
+++ b/tests/test_compare_with_default_qubit.py
@@ -49,8 +49,8 @@ class CompareWithDefaultQubitTest(BaseTest):
                 self.devices.append(
                     IbmQQiskitDevice(wires=self.num_subsystems, shots=8 * 1024, ibmqx_token=self.args.ibmqx_token))
             else:
-                log.warning(
-                    "Skipping test of the IbmQQiskitDevice device because IBM login credentials could not be found in the PennyLane configuration file.")
+                log.warning("Skipping test of the IbmQQiskitDevice device because IBM login credentials "
+                            "could not be found in the PennyLane configuration file.")
 
     def test_simple_circuits(self):
         """Automatically compare the behavior on simple circuits"""

--- a/tests/test_compare_with_default_qubit.py
+++ b/tests/test_compare_with_default_qubit.py
@@ -41,13 +41,13 @@ class CompareWithDefaultQubitTest(BaseTest):
 
         self.devices = []
         if self.args.device == 'basicaer' or self.args.device == 'all':
-            self.devices.append(BasicAerQiskitDevice(wires=self.num_subsystems))
+            self.devices.append(BasicAerQiskitDevice(wires=self.num_subsystems, shots=8 * 1024))
         if self.args.device == 'aer' or self.args.device == 'all':
-            self.devices.append(AerQiskitDevice(wires=self.num_subsystems))
+            self.devices.append(AerQiskitDevice(wires=self.num_subsystems, shots=8 * 1024))
         if self.args.device == 'ibmq' or self.args.device == 'all':
-            if IBMQX_TOKEN is not None:
+            if self.args.ibmqx_token is not None:
                 self.devices.append(
-                    IbmQQiskitDevice(wires=self.num_subsystems, num_runs=8 * 1024, ibmqx_token=IBMQX_TOKEN))
+                    IbmQQiskitDevice(wires=self.num_subsystems, shots=8 * 1024, ibmqx_token=self.args.ibmqx_token))
             else:
                 log.warning(
                     "Skipping test of the IbmQQiskitDevice device because IBM login credentials could not be found in the PennyLane configuration file.")

--- a/tests/test_compare_with_default_qubit.py
+++ b/tests/test_compare_with_default_qubit.py
@@ -73,7 +73,8 @@ class CompareWithDefaultQubitTest(BaseTest):
             for operation in dev.operations:
                 for observable in dev.expectations:
                     log.info(
-                        "Running device " + dev.short_name + " with a circuit consisting of a " + operation + " Operation followed by a " + observable + " Expectation")
+                        "Running device {} with a circuit consisting of a {} Operation followed by a {} Expectation".format(
+                            dev.short_name, operation, observable))
 
                     @qml.qnode(dev)
                     def circuit():

--- a/tests/test_compare_with_default_qubit.py
+++ b/tests/test_compare_with_default_qubit.py
@@ -135,7 +135,7 @@ class CompareWithDefaultQubitTest(BaseTest):
                         observable_wires = list(
                             range(observable_class.num_wires)) if observable_class.num_wires > 1 else 0
 
-                        operation_class(*operation_pars, operation_wires)
+                        operation_class(*operation_pars, wires=operation_wires)
                         return observable_class(*observable_pars, observable_wires)
 
                     output = circuit()

--- a/tests/test_compare_with_default_qubit.py
+++ b/tests/test_compare_with_default_qubit.py
@@ -131,7 +131,7 @@ class CompareWithDefaultQubitTest(BaseTest):
                             observable_pars = {}
 
                         # apply to the first wires
-                        operation_wires = list(range(operation_class.num_wires)) if operation_class.num_wires > 1 else 0
+                        operation_wires = list(range(operation_class.num_wires)) if operation_class.num_wires > 0 else list(range(self.num_subsystems))
                         observable_wires = list(
                             range(observable_class.num_wires)) if observable_class.num_wires > 1 else 0
 

--- a/tests/test_compare_with_default_qubit.py
+++ b/tests/test_compare_with_default_qubit.py
@@ -39,7 +39,7 @@ class CompareWithDefaultQubitTest(BaseTest):
     def setUp(self):
         super().setUp()
 
-        self.devices = [DefaultQubit(wires=self.num_subsystems, shots=8 * 1024)]
+        self.devices = [DefaultQubit(wires=self.num_subsystems, shots=0)]
         if self.args.device == 'basicaer' or self.args.device == 'all':
             self.devices.append(BasicAerQiskitDevice(wires=self.num_subsystems, shots=8 * 1024))
         if self.args.device == 'aer' or self.args.device == 'all':
@@ -114,7 +114,6 @@ class CompareWithDefaultQubitTest(BaseTest):
                                 operation_pars = [np.array(random_ket)]
                             elif str(operation) == "BasisState":
                                 operation_pars = [random_zero_one_pool[:self.num_subsystems]]
-                                operation_class.num_wires = self.num_subsystems
                             else:
                                 raise IgnoreOperationException(
                                     'Skipping in automatic test because I don\'t know how to generate parameters for the operation ' + operation)

--- a/tests/test_compare_with_default_qubit.py
+++ b/tests/test_compare_with_default_qubit.py
@@ -40,11 +40,11 @@ class CompareWithDefaultQubitTest(BaseTest):
         super().setUp()
 
         self.devices = []
-        if self.args.provider == 'basicaer' or self.args.provider == 'all':
+        if self.args.device == 'basicaer' or self.args.device == 'all':
             self.devices.append(BasicAerQiskitDevice(wires=self.num_subsystems))
-        if self.args.provider == 'aer' or self.args.provider == 'all':
+        if self.args.device == 'aer' or self.args.device == 'all':
             self.devices.append(AerQiskitDevice(wires=self.num_subsystems))
-        if self.args.provider == 'ibm' or self.args.provider == 'all':
+        if self.args.device == 'ibmq' or self.args.device == 'all':
             if IBMQX_TOKEN is not None:
                 self.devices.append(
                     IbmQQiskitDevice(wires=self.num_subsystems, num_runs=8 * 1024, ibmqx_token=IBMQX_TOKEN))

--- a/tests/test_compare_with_default_qubit.py
+++ b/tests/test_compare_with_default_qubit.py
@@ -158,6 +158,11 @@ class CompareWithDefaultQubitTest(BaseTest):
                     str(list(val.values())), ', '.join(list(val.keys())),
                     str(key[0]), str(key[1]))
 
+                if 'DefaultQubit(shots=0)' not in val:
+                    log.info("Operation %s followed by Expectation %s has no pendant in the DefaultQubit "
+                             "device. Skipping.", key[0], key[1])
+                    continue
+
                 reference_output = val['DefaultQubit(shots=0)']
                 self.assertAllAlmostEqual(val.values(), len(val) * [reference_output], delta=self.tol, msg=failed_message)
 

--- a/tests/test_compare_with_default_qubit.py
+++ b/tests/test_compare_with_default_qubit.py
@@ -39,7 +39,7 @@ class CompareWithDefaultQubitTest(BaseTest):
     def setUp(self):
         super().setUp()
 
-        self.devices = []
+        self.devices = [DefaultQubit(wires=self.num_subsystems, shots=8 * 1024)]
         if self.args.device == 'basicaer' or self.args.device == 'all':
             self.devices.append(BasicAerQiskitDevice(wires=self.num_subsystems, shots=8 * 1024))
         if self.args.device == 'aer' or self.args.device == 'all':

--- a/tests/test_compare_with_default_qubit.py
+++ b/tests/test_compare_with_default_qubit.py
@@ -39,7 +39,7 @@ class CompareWithDefaultQubitTest(BaseTest):
     def setUp(self):
         super().setUp()
 
-        self.devices = [DefaultQubit(wires=self.num_subsystems)]
+        self.devices = []
         if self.args.provider == 'basicaer' or self.args.provider == 'all':
             self.devices.append(BasicAerQiskitDevice(wires=self.num_subsystems))
         if self.args.provider == 'aer' or self.args.provider == 'all':

--- a/tests/test_device_initialization.py
+++ b/tests/test_device_initialization.py
@@ -334,7 +334,7 @@ class DeviceInitialization(BaseTest):
             qiskit.IBMQ.disable_accounts()
             try:
                 for backend in backends:
-                    qml.device('qiskit.ibm', wires=1, ibmqx_token=self.args.ibmqx_token, backend=backend)
+                    qml.device('qiskit.ibmq', wires=1, ibmqx_token=self.args.ibmqx_token, backend=backend)
             except DeviceError:
                 raise Exception("This test is expected to fail until pennylane-qiskit is installed.")
 

--- a/tests/test_device_initialization.py
+++ b/tests/test_device_initialization.py
@@ -20,11 +20,11 @@ import os
 import unittest
 
 from pennylane import DeviceError
-from qiskit import IBMQ
 from qiskit.providers.aer import noise
 from qiskit.providers.aer.noise import NoiseModel
+from qiskit.providers.models import BackendProperties
 
-from defaults import pennylane as qml, BaseTest, IBMQX_TOKEN
+from defaults import pennylane as qml, BaseTest
 from pennylane_qiskit import IbmQQiskitDevice, AerQiskitDevice, BasicAerQiskitDevice
 
 log.getLogger('defaults')
@@ -43,7 +43,7 @@ class DeviceInitialization(BaseTest):
         if token_from_environment is not None:
             del os.environ['IBMQX_TOKEN']
 
-        if self.args.provider == 'ibm' or self.args.provider == 'all':
+        if self.args.device == 'ibmq' or self.args.device == 'all':
             self.assertRaises(ValueError, IbmQQiskitDevice, wires=self.num_subsystems,
                               msg='Expected a ValueError if no IBMQX token is present.')
 
@@ -54,16 +54,16 @@ class DeviceInitialization(BaseTest):
             self.assertEqual(token_from_environment, token_from_environment_back)
 
     def test_shots(self):
-        if self.args.provider == 'ibmq_qasm_simulator' or self.args.provider == 'all':
+        if self.args.device == 'ibmq' or self.args.device == 'all':
             shots = 5
-            dev1 = IbmQQiskitDevice(wires=self.num_subsystems, shots=shots, ibmqx_token=IBMQX_TOKEN)
+            dev1 = IbmQQiskitDevice(wires=self.num_subsystems, shots=shots, ibmqx_token=self.args.ibmqx_token)
             self.assertEqual(shots, dev1.shots)
 
     def test_noise_model_for_aer(self):
         try:
             noise_model = self._get_noise_model()  # type: NoiseModel
 
-            dev = qml.device('qiskit.aer', wires=self.num_subsystems, ibmqx_token=IBMQX_TOKEN, noise_model=noise_model)
+            dev = qml.device('qiskit.aer', wires=self.num_subsystems, noise_model=noise_model)
             self.assertIsNotNone(dev._noise_model)
             self.assertEqual(noise_model.as_dict(), dev._noise_model.as_dict())
 
@@ -78,8 +78,7 @@ class DeviceInitialization(BaseTest):
         try:
             noise_model = self._get_noise_model()
 
-            dev = qml.device('qiskit.basicaer', wires=self.num_subsystems, ibmqx_token=IBMQX_TOKEN,
-                             noise_model=noise_model)
+            dev = qml.device('qiskit.basicaer', wires=self.num_subsystems, noise_model=noise_model)
             self.assertIsNotNone(dev._noise_model)
             self.assertEqual(noise_model.as_dict(), dev._noise_model.as_dict())
 
@@ -92,37 +91,255 @@ class DeviceInitialization(BaseTest):
 
     @classmethod
     def _get_noise_model(cls):
-        IBMQ.enable_account(IBMQX_TOKEN)
-        device = IBMQ.get_backend('ibmqx4')
-        properties = device.properties()
+        properties = BackendProperties.from_dict({'backend_name': 'ibmqx4',
+                                                  'backend_version': '1.0.0',
+                                                  'gates': [{'gate': 'u1',
+                                                             'parameters': [{'date': '2019-05-08T09:57:07+00:00',
+                                                                             'name': 'gate_error',
+                                                                             'unit': '',
+                                                                             'value': 0.0}],
+                                                             'qubits': [0]},
+                                                            {'gate': 'u2',
+                                                             'parameters': [{'date': '2019-05-08T09:57:07+00:00',
+                                                                             'name': 'gate_error',
+                                                                             'unit': '',
+                                                                             'value': 0.0009443532335046134}],
+                                                             'qubits': [0]},
+                                                            {'gate': 'u3',
+                                                             'parameters': [{'date': '2019-05-08T09:57:07+00:00',
+                                                                             'name': 'gate_error',
+                                                                             'unit': '',
+                                                                             'value': 0.0018887064670092268}],
+                                                             'qubits': [0]},
+                                                            {'gate': 'u1',
+                                                             'parameters': [{'date': '2019-05-08T09:57:07+00:00',
+                                                                             'name': 'gate_error',
+                                                                             'unit': '',
+                                                                             'value': 0.0}],
+                                                             'qubits': [1]},
+                                                            {'gate': 'u2',
+                                                             'parameters': [{'date': '2019-05-08T09:57:07+00:00',
+                                                                             'name': 'gate_error',
+                                                                             'unit': '',
+                                                                             'value': 0.0012019552727863259}],
+                                                             'qubits': [1]},
+                                                            {'gate': 'u3',
+                                                             'parameters': [{'date': '2019-05-08T09:57:07+00:00',
+                                                                             'name': 'gate_error',
+                                                                             'unit': '',
+                                                                             'value': 0.0024039105455726517}],
+                                                             'qubits': [1]},
+                                                            {'gate': 'u1',
+                                                             'parameters': [{'date': '2019-05-08T09:57:07+00:00',
+                                                                             'name': 'gate_error',
+                                                                             'unit': '',
+                                                                             'value': 0.0}],
+                                                             'qubits': [2]},
+                                                            {'gate': 'u2',
+                                                             'parameters': [{'date': '2019-05-08T09:57:07+00:00',
+                                                                             'name': 'gate_error',
+                                                                             'unit': '',
+                                                                             'value': 0.0012019552727863259}],
+                                                             'qubits': [2]},
+                                                            {'gate': 'u3',
+                                                             'parameters': [{'date': '2019-05-08T09:57:07+00:00',
+                                                                             'name': 'gate_error',
+                                                                             'unit': '',
+                                                                             'value': 0.0024039105455726517}],
+                                                             'qubits': [2]},
+                                                            {'gate': 'u1',
+                                                             'parameters': [{'date': '2019-05-08T09:57:07+00:00',
+                                                                             'name': 'gate_error',
+                                                                             'unit': '',
+                                                                             'value': 0.0}],
+                                                             'qubits': [3]},
+                                                            {'gate': 'u2',
+                                                             'parameters': [{'date': '2019-05-08T09:57:07+00:00',
+                                                                             'name': 'gate_error',
+                                                                             'unit': '',
+                                                                             'value': 0.0013737021608475342}],
+                                                             'qubits': [3]},
+                                                            {'gate': 'u3',
+                                                             'parameters': [{'date': '2019-05-08T09:57:07+00:00',
+                                                                             'name': 'gate_error',
+                                                                             'unit': '',
+                                                                             'value': 0.0027474043216950683}],
+                                                             'qubits': [3]},
+                                                            {'gate': 'u1',
+                                                             'parameters': [{'date': '2019-05-08T09:57:07+00:00',
+                                                                             'name': 'gate_error',
+                                                                             'unit': '',
+                                                                             'value': 0.0}],
+                                                             'qubits': [4]},
+                                                            {'gate': 'u2',
+                                                             'parameters': [{'date': '2019-05-08T09:57:07+00:00',
+                                                                             'name': 'gate_error',
+                                                                             'unit': '',
+                                                                             'value': 0.001803112096824766}],
+                                                             'qubits': [4]},
+                                                            {'gate': 'u3',
+                                                             'parameters': [{'date': '2019-05-08T09:57:07+00:00',
+                                                                             'name': 'gate_error',
+                                                                             'unit': '',
+                                                                             'value': 0.003606224193649532}],
+                                                             'qubits': [4]},
+                                                            {'gate': 'cx',
+                                                             'name': 'CX1_0',
+                                                             'parameters': [{'date': '2019-05-08T01:27:07+00:00',
+                                                                             'name': 'gate_error',
+                                                                             'unit': '',
+                                                                             'value': 0.024311890455604945}],
+                                                             'qubits': [1, 0]},
+                                                            {'gate': 'cx',
+                                                             'name': 'CX2_0',
+                                                             'parameters': [{'date': '2019-05-08T01:32:39+00:00',
+                                                                             'name': 'gate_error',
+                                                                             'unit': '',
+                                                                             'value': 0.023484363587478657}],
+                                                             'qubits': [2, 0]},
+                                                            {'gate': 'cx',
+                                                             'name': 'CX2_1',
+                                                             'parameters': [{'date': '2019-05-08T01:38:20+00:00',
+                                                                             'name': 'gate_error',
+                                                                             'unit': '',
+                                                                             'value': 0.04885221406150694}],
+                                                             'qubits': [2, 1]},
+                                                            {'gate': 'cx',
+                                                             'name': 'CX3_2',
+                                                             'parameters': [{'date': '2019-05-08T01:44:07+00:00',
+                                                                             'name': 'gate_error',
+                                                                             'unit': '',
+                                                                             'value': 0.06682678733530181}],
+                                                             'qubits': [3, 2]},
+                                                            {'gate': 'cx',
+                                                             'name': 'CX3_4',
+                                                             'parameters': [{'date': '2019-05-08T01:50:07+00:00',
+                                                                             'name': 'gate_error',
+                                                                             'unit': '',
+                                                                             'value': 0.05217118636435464}],
+                                                             'qubits': [3, 4]},
+                                                            {'gate': 'cx',
+                                                             'name': 'CX4_2',
+                                                             'parameters': [{'date': '2019-05-08T01:56:04+00:00',
+                                                                             'name': 'gate_error',
+                                                                             'unit': '',
+                                                                             'value': 0.06446497941268642}],
+                                                             'qubits': [4, 2]}],
+                                                  'general': [],
+                                                  'last_update_date': '2019-05-08T01:56:04+00:00',
+                                                  'qconsole': False,
+                                                  'qubits': [[{'date': '2019-05-08T01:16:56+00:00',
+                                                               'name': 'T1',
+                                                               'unit': 'µs',
+                                                               'value': 43.21767480545737},
+                                                              {'date': '2019-05-08T01:17:40+00:00',
+                                                               'name': 'T2',
+                                                               'unit': 'µs',
+                                                               'value': 19.77368032971812},
+                                                              {'date': '2019-05-08T01:56:04+00:00',
+                                                               'name': 'frequency',
+                                                               'unit': 'GHz',
+                                                               'value': 5.246576101635769},
+                                                              {'date': '2019-05-08T01:16:37+00:00',
+                                                               'name': 'readout_error',
+                                                               'unit': '',
+                                                               'value': 0.08650000000000002}],
+                                                             [{'date': '2019-05-08T01:16:56+00:00',
+                                                               'name': 'T1',
+                                                               'unit': 'µs',
+                                                               'value': 43.87997000828745},
+                                                              {'date': '2019-05-08T01:18:27+00:00',
+                                                               'name': 'T2',
+                                                               'unit': 'µs',
+                                                               'value': 11.390521028550571},
+                                                              {'date': '2019-05-08T01:56:04+00:00',
+                                                               'name': 'frequency',
+                                                               'unit': 'GHz',
+                                                               'value': 5.298309751315148},
+                                                              {'date': '2019-05-08T01:16:37+00:00',
+                                                               'name': 'readout_error',
+                                                               'unit': '',
+                                                               'value': 0.07999999999999996}],
+                                                             [{'date': '2019-05-07T09:14:18+00:00',
+                                                               'name': 'T1',
+                                                               'unit': 'µs',
+                                                               'value': 48.97128225850014},
+                                                              {'date': '2019-05-08T01:19:07+00:00',
+                                                               'name': 'T2',
+                                                               'unit': 'µs',
+                                                               'value': 31.06845465651204},
+                                                              {'date': '2019-05-08T01:56:04+00:00',
+                                                               'name': 'frequency',
+                                                               'unit': 'GHz',
+                                                               'value': 5.3383288291854765},
+                                                              {'date': '2019-05-08T01:16:37+00:00',
+                                                               'name': 'readout_error',
+                                                               'unit': '',
+                                                               'value': 0.038250000000000006}],
+                                                             [{'date': '2019-05-08T01:16:56+00:00',
+                                                               'name': 'T1',
+                                                               'unit': 'µs',
+                                                               'value': 38.30486582843196},
+                                                              {'date': '2019-05-08T01:18:27+00:00',
+                                                               'name': 'T2',
+                                                               'unit': 'µs',
+                                                               'value': 32.35546811356613},
+                                                              {'date': '2019-05-08T01:56:04+00:00',
+                                                               'name': 'frequency',
+                                                               'unit': 'GHz',
+                                                               'value': 5.426109336844823},
+                                                              {'date': '2019-05-08T01:16:37+00:00',
+                                                               'name': 'readout_error',
+                                                               'unit': '',
+                                                               'value': 0.35675}],
+                                                             [{'date': '2019-05-08T01:16:56+00:00',
+                                                               'name': 'T1',
+                                                               'unit': 'µs',
+                                                               'value': 36.02606265575505},
+                                                              {'date': '2019-05-07T09:15:02+00:00',
+                                                               'name': 'T2',
+                                                               'unit': 'µs',
+                                                               'value': 4.461644223370699},
+                                                              {'date': '2019-05-08T01:56:04+00:00',
+                                                               'name': 'frequency',
+                                                               'unit': 'GHz',
+                                                               'value': 5.174501299220437},
+                                                              {'date': '2019-05-08T01:16:37+00:00',
+                                                               'name': 'readout_error',
+                                                               'unit': '',
+                                                               'value': 0.2715000000000001}]]})
 
         return noise.device.basic_device_noise_model(properties)
 
-    def test_initiatlization_via_pennylane(self):
+    def test_initialization_via_pennylane(self):
         for short_name in [
             'qiskit.aer',
             'qiskit.basicaer',
-            'qiskit.ibm'
+            'qiskit.ibmq'
         ]:
             try:
-                qml.device(short_name, wires=2, ibmqx_token=IBMQX_TOKEN)
+                if self.args.ibmqx_token is None:
+                    log.warning("Device initialization cannot be tested as there is no IBMQX token configured. "
+                                "The test concerning the ibmq will be skipped.")
+                else:
+                    qml.device(short_name, wires=2, ibmqx_token=self.args.ibmqx_token)
             except DeviceError:
                 raise Exception("This test is expected to fail until pennylane-qiskit is installed.")
 
     def test_ibm_device(self):
-        if self.args.provider in ['ibm', 'all']:
+        if self.args.device in ['ibmq', 'all']:
             import qiskit
-            qiskit.IBMQ.enable_account(token=IBMQX_TOKEN)
+            qiskit.IBMQ.enable_account(token=self.args.ibmqx_token)
             backends = qiskit.IBMQ.backends()
             qiskit.IBMQ.disable_accounts()
             try:
                 for backend in backends:
-                    qml.device('qiskit.ibm', wires=1, ibmqx_token=IBMQX_TOKEN, backend=backend)
+                    qml.device('qiskit.ibm', wires=1, ibmqx_token=self.args.ibmqx_token, backend=backend)
             except DeviceError:
                 raise Exception("This test is expected to fail until pennylane-qiskit is installed.")
 
     def test_aer_device(self):
-        if self.args.provider in ['aer', 'all']:
+        if self.args.device in ['aer', 'all']:
             import qiskit
             try:
                 for backend in qiskit.Aer.backends():
@@ -131,7 +348,7 @@ class DeviceInitialization(BaseTest):
                 raise Exception("This test is expected to fail until pennylane-qiskit is installed.")
 
     def test_basicaer_device(self):
-        if self.args.provider in ['aer', 'all']:
+        if self.args.device in ['basicaer', 'all']:
             import qiskit
             try:
                 for backend in qiskit.BasicAer.backends():

--- a/tests/test_docs.py
+++ b/tests/test_docs.py
@@ -36,11 +36,11 @@ class DocumentationTest(BaseTest):
         super().setUp()
 
         self.devices = []
-        if self.args.provider == 'basicaer' or self.args.provider == 'all':
+        if self.args.device == 'basicaer' or self.args.device == 'all':
             self.devices.append(BasicAerQiskitDevice(wires=self.num_subsystems))
-        if self.args.provider == 'aer' or self.args.provider == 'all':
+        if self.args.device == 'aer' or self.args.device == 'all':
             self.devices.append(AerQiskitDevice(wires=self.num_subsystems))
-        if self.args.provider == 'ibm' or self.args.provider == 'all':
+        if self.args.device == 'ibmq' or self.args.device == 'all':
             self.devices.append(IbmQQiskitDevice(wires=self.num_subsystems, num_runs=8 * 1024, ibmqx_token=IBMQX_TOKEN))
 
     def test_device_docstrings(self):

--- a/tests/test_simple_circuits.py
+++ b/tests/test_simple_circuits.py
@@ -14,17 +14,17 @@
 """
 Unit tests for :mod:`pennylane_qiskit` simple circuits.
 """
-import cmath
 import logging as log
-import math
 import unittest
 
+import cmath
+import math
 from pennylane import numpy as np
+from qiskit.providers.aer import noise
+from qiskit.providers.models import BackendProperties
 
 from defaults import pennylane as qml, BaseTest, IBMQX_TOKEN
 from pennylane_qiskit import BasicAerQiskitDevice, IbmQQiskitDevice, AerQiskitDevice
-from qiskit import IBMQ
-from qiskit.providers.aer import noise
 
 log.getLogger('defaults')
 
@@ -40,11 +40,11 @@ class SimpleCircuitsTest(BaseTest):
         super().setUp()
 
         self.devices = []
-        if self.args.provider == 'basicaer' or self.args.provider == 'all':
+        if self.args.device == 'basicaer' or self.args.device == 'all':
             self.devices.append(BasicAerQiskitDevice(wires=self.num_subsystems))
-        if self.args.provider == 'aer' or self.args.provider == 'all':
+        if self.args.device == 'aer' or self.args.device == 'all':
             self.devices.append(AerQiskitDevice(wires=self.num_subsystems))
-        if self.args.provider == 'ibm' or self.args.provider == 'all':
+        if self.args.device == 'ibmq' or self.args.device == 'all':
             if IBMQX_TOKEN is not None:
                 self.devices.append(
                     IbmQQiskitDevice(wires=self.num_subsystems, num_runs=8 * 1024, ibmqx_token=IBMQX_TOKEN))
@@ -52,9 +52,244 @@ class SimpleCircuitsTest(BaseTest):
                 log.warning("Skipping test of the IbmQQiskitDevice device because IBM login credentials could not be "
                             "found in the PennyLane configuration file.")
 
-        IBMQ.enable_account(IBMQX_TOKEN)
-        device = IBMQ.get_backend('ibmqx4')
-        properties = device.properties()
+        properties = BackendProperties.from_dict({'backend_name': 'ibmqx4',
+                                                                   'backend_version': '1.0.0',
+                                                                   'gates': [{'gate': 'u1',
+                                                                              'parameters': [
+                                                                                  {'date': '2019-05-08T09:57:07+00:00',
+                                                                                   'name': 'gate_error',
+                                                                                   'unit': '',
+                                                                                   'value': 0.0}],
+                                                                              'qubits': [0]},
+                                                                             {'gate': 'u2',
+                                                                              'parameters': [
+                                                                                  {'date': '2019-05-08T09:57:07+00:00',
+                                                                                   'name': 'gate_error',
+                                                                                   'unit': '',
+                                                                                   'value': 0.0009443532335046134}],
+                                                                              'qubits': [0]},
+                                                                             {'gate': 'u3',
+                                                                              'parameters': [
+                                                                                  {'date': '2019-05-08T09:57:07+00:00',
+                                                                                   'name': 'gate_error',
+                                                                                   'unit': '',
+                                                                                   'value': 0.0018887064670092268}],
+                                                                              'qubits': [0]},
+                                                                             {'gate': 'u1',
+                                                                              'parameters': [
+                                                                                  {'date': '2019-05-08T09:57:07+00:00',
+                                                                                   'name': 'gate_error',
+                                                                                   'unit': '',
+                                                                                   'value': 0.0}],
+                                                                              'qubits': [1]},
+                                                                             {'gate': 'u2',
+                                                                              'parameters': [
+                                                                                  {'date': '2019-05-08T09:57:07+00:00',
+                                                                                   'name': 'gate_error',
+                                                                                   'unit': '',
+                                                                                   'value': 0.0012019552727863259}],
+                                                                              'qubits': [1]},
+                                                                             {'gate': 'u3',
+                                                                              'parameters': [
+                                                                                  {'date': '2019-05-08T09:57:07+00:00',
+                                                                                   'name': 'gate_error',
+                                                                                   'unit': '',
+                                                                                   'value': 0.0024039105455726517}],
+                                                                              'qubits': [1]},
+                                                                             {'gate': 'u1',
+                                                                              'parameters': [
+                                                                                  {'date': '2019-05-08T09:57:07+00:00',
+                                                                                   'name': 'gate_error',
+                                                                                   'unit': '',
+                                                                                   'value': 0.0}],
+                                                                              'qubits': [2]},
+                                                                             {'gate': 'u2',
+                                                                              'parameters': [
+                                                                                  {'date': '2019-05-08T09:57:07+00:00',
+                                                                                   'name': 'gate_error',
+                                                                                   'unit': '',
+                                                                                   'value': 0.0012019552727863259}],
+                                                                              'qubits': [2]},
+                                                                             {'gate': 'u3',
+                                                                              'parameters': [
+                                                                                  {'date': '2019-05-08T09:57:07+00:00',
+                                                                                   'name': 'gate_error',
+                                                                                   'unit': '',
+                                                                                   'value': 0.0024039105455726517}],
+                                                                              'qubits': [2]},
+                                                                             {'gate': 'u1',
+                                                                              'parameters': [
+                                                                                  {'date': '2019-05-08T09:57:07+00:00',
+                                                                                   'name': 'gate_error',
+                                                                                   'unit': '',
+                                                                                   'value': 0.0}],
+                                                                              'qubits': [3]},
+                                                                             {'gate': 'u2',
+                                                                              'parameters': [
+                                                                                  {'date': '2019-05-08T09:57:07+00:00',
+                                                                                   'name': 'gate_error',
+                                                                                   'unit': '',
+                                                                                   'value': 0.0013737021608475342}],
+                                                                              'qubits': [3]},
+                                                                             {'gate': 'u3',
+                                                                              'parameters': [
+                                                                                  {'date': '2019-05-08T09:57:07+00:00',
+                                                                                   'name': 'gate_error',
+                                                                                   'unit': '',
+                                                                                   'value': 0.0027474043216950683}],
+                                                                              'qubits': [3]},
+                                                                             {'gate': 'u1',
+                                                                              'parameters': [
+                                                                                  {'date': '2019-05-08T09:57:07+00:00',
+                                                                                   'name': 'gate_error',
+                                                                                   'unit': '',
+                                                                                   'value': 0.0}],
+                                                                              'qubits': [4]},
+                                                                             {'gate': 'u2',
+                                                                              'parameters': [
+                                                                                  {'date': '2019-05-08T09:57:07+00:00',
+                                                                                   'name': 'gate_error',
+                                                                                   'unit': '',
+                                                                                   'value': 0.001803112096824766}],
+                                                                              'qubits': [4]},
+                                                                             {'gate': 'u3',
+                                                                              'parameters': [
+                                                                                  {'date': '2019-05-08T09:57:07+00:00',
+                                                                                   'name': 'gate_error',
+                                                                                   'unit': '',
+                                                                                   'value': 0.003606224193649532}],
+                                                                              'qubits': [4]},
+                                                                             {'gate': 'cx',
+                                                                              'name': 'CX1_0',
+                                                                              'parameters': [
+                                                                                  {'date': '2019-05-08T01:27:07+00:00',
+                                                                                   'name': 'gate_error',
+                                                                                   'unit': '',
+                                                                                   'value': 0.024311890455604945}],
+                                                                              'qubits': [1, 0]},
+                                                                             {'gate': 'cx',
+                                                                              'name': 'CX2_0',
+                                                                              'parameters': [
+                                                                                  {'date': '2019-05-08T01:32:39+00:00',
+                                                                                   'name': 'gate_error',
+                                                                                   'unit': '',
+                                                                                   'value': 0.023484363587478657}],
+                                                                              'qubits': [2, 0]},
+                                                                             {'gate': 'cx',
+                                                                              'name': 'CX2_1',
+                                                                              'parameters': [
+                                                                                  {'date': '2019-05-08T01:38:20+00:00',
+                                                                                   'name': 'gate_error',
+                                                                                   'unit': '',
+                                                                                   'value': 0.04885221406150694}],
+                                                                              'qubits': [2, 1]},
+                                                                             {'gate': 'cx',
+                                                                              'name': 'CX3_2',
+                                                                              'parameters': [
+                                                                                  {'date': '2019-05-08T01:44:07+00:00',
+                                                                                   'name': 'gate_error',
+                                                                                   'unit': '',
+                                                                                   'value': 0.06682678733530181}],
+                                                                              'qubits': [3, 2]},
+                                                                             {'gate': 'cx',
+                                                                              'name': 'CX3_4',
+                                                                              'parameters': [
+                                                                                  {'date': '2019-05-08T01:50:07+00:00',
+                                                                                   'name': 'gate_error',
+                                                                                   'unit': '',
+                                                                                   'value': 0.05217118636435464}],
+                                                                              'qubits': [3, 4]},
+                                                                             {'gate': 'cx',
+                                                                              'name': 'CX4_2',
+                                                                              'parameters': [
+                                                                                  {'date': '2019-05-08T01:56:04+00:00',
+                                                                                   'name': 'gate_error',
+                                                                                   'unit': '',
+                                                                                   'value': 0.06446497941268642}],
+                                                                              'qubits': [4, 2]}],
+                                                                   'general': [],
+                                                                   'last_update_date': '2019-05-08T01:56:04+00:00',
+                                                                   'qconsole': False,
+                                                                   'qubits': [[{'date': '2019-05-08T01:16:56+00:00',
+                                                                                'name': 'T1',
+                                                                                'unit': 'µs',
+                                                                                'value': 43.21767480545737},
+                                                                               {'date': '2019-05-08T01:17:40+00:00',
+                                                                                'name': 'T2',
+                                                                                'unit': 'µs',
+                                                                                'value': 19.77368032971812},
+                                                                               {'date': '2019-05-08T01:56:04+00:00',
+                                                                                'name': 'frequency',
+                                                                                'unit': 'GHz',
+                                                                                'value': 5.246576101635769},
+                                                                               {'date': '2019-05-08T01:16:37+00:00',
+                                                                                'name': 'readout_error',
+                                                                                'unit': '',
+                                                                                'value': 0.08650000000000002}],
+                                                                              [{'date': '2019-05-08T01:16:56+00:00',
+                                                                                'name': 'T1',
+                                                                                'unit': 'µs',
+                                                                                'value': 43.87997000828745},
+                                                                               {'date': '2019-05-08T01:18:27+00:00',
+                                                                                'name': 'T2',
+                                                                                'unit': 'µs',
+                                                                                'value': 11.390521028550571},
+                                                                               {'date': '2019-05-08T01:56:04+00:00',
+                                                                                'name': 'frequency',
+                                                                                'unit': 'GHz',
+                                                                                'value': 5.298309751315148},
+                                                                               {'date': '2019-05-08T01:16:37+00:00',
+                                                                                'name': 'readout_error',
+                                                                                'unit': '',
+                                                                                'value': 0.07999999999999996}],
+                                                                              [{'date': '2019-05-07T09:14:18+00:00',
+                                                                                'name': 'T1',
+                                                                                'unit': 'µs',
+                                                                                'value': 48.97128225850014},
+                                                                               {'date': '2019-05-08T01:19:07+00:00',
+                                                                                'name': 'T2',
+                                                                                'unit': 'µs',
+                                                                                'value': 31.06845465651204},
+                                                                               {'date': '2019-05-08T01:56:04+00:00',
+                                                                                'name': 'frequency',
+                                                                                'unit': 'GHz',
+                                                                                'value': 5.3383288291854765},
+                                                                               {'date': '2019-05-08T01:16:37+00:00',
+                                                                                'name': 'readout_error',
+                                                                                'unit': '',
+                                                                                'value': 0.038250000000000006}],
+                                                                              [{'date': '2019-05-08T01:16:56+00:00',
+                                                                                'name': 'T1',
+                                                                                'unit': 'µs',
+                                                                                'value': 38.30486582843196},
+                                                                               {'date': '2019-05-08T01:18:27+00:00',
+                                                                                'name': 'T2',
+                                                                                'unit': 'µs',
+                                                                                'value': 32.35546811356613},
+                                                                               {'date': '2019-05-08T01:56:04+00:00',
+                                                                                'name': 'frequency',
+                                                                                'unit': 'GHz',
+                                                                                'value': 5.426109336844823},
+                                                                               {'date': '2019-05-08T01:16:37+00:00',
+                                                                                'name': 'readout_error',
+                                                                                'unit': '',
+                                                                                'value': 0.35675}],
+                                                                              [{'date': '2019-05-08T01:16:56+00:00',
+                                                                                'name': 'T1',
+                                                                                'unit': 'µs',
+                                                                                'value': 36.02606265575505},
+                                                                               {'date': '2019-05-07T09:15:02+00:00',
+                                                                                'name': 'T2',
+                                                                                'unit': 'µs',
+                                                                                'value': 4.461644223370699},
+                                                                               {'date': '2019-05-08T01:56:04+00:00',
+                                                                                'name': 'frequency',
+                                                                                'unit': 'GHz',
+                                                                                'value': 5.174501299220437},
+                                                                               {'date': '2019-05-08T01:16:37+00:00',
+                                                                                'name': 'readout_error',
+                                                                                'unit': '',
+                                                                                'value': 0.2715000000000001}]]})
 
         self.noise_model = noise.device.basic_device_noise_model(properties)
 

--- a/tests/test_simple_circuits.py
+++ b/tests/test_simple_circuits.py
@@ -330,7 +330,7 @@ class SimpleCircuitsTest(BaseTest):
                 qml.CNOT(wires=[0, 1])
                 return qml.expval.PauliZ(wires=1)
 
-            self.assertAllAlmostEqual(0.96875, np.array(circuit(0.2, 0.1, 0.3)), delta=self.tol)
+            self.assertAllAlmostEqual(0.96875, circuit(0.2, 0.1, 0.3), delta=self.tol)
 
     def test_arbitrary_state(self):
         """Test BasisState with preparations on the whole system."""

--- a/tests/test_unsupported_operations.py
+++ b/tests/test_unsupported_operations.py
@@ -38,11 +38,11 @@ class UnsupportedOperationTest(BaseTest):
         super().setUp()
 
         self.devices = []
-        if self.args.provider == 'basicaer' or self.args.provider == 'all':
+        if self.args.device == 'basicaer' or self.args.device == 'all':
             self.devices.append(BasicAerQiskitDevice(wires=self.num_subsystems))
-        if self.args.provider == 'aer' or self.args.provider == 'all':
+        if self.args.device == 'aer' or self.args.device == 'all':
             self.devices.append(AerQiskitDevice(wires=self.num_subsystems))
-        if self.args.provider == 'ibm' or self.args.provider == 'all':
+        if self.args.device == 'ibmq' or self.args.device == 'all':
             if IBMQX_TOKEN is not None:
                 self.devices.append(
                     IbmQQiskitDevice(wires=self.num_subsystems, num_runs=8 * 1024, ibmqx_token=IBMQX_TOKEN))


### PR DESCRIPTION
After the expectation fix by @josh146 one test, test_compare_with_default_qubit.py, actually got re-activated and failed. 
It showed that base functionality was not working and also showed that for sime operations as the QubitStateVector and others deviated from the default behavior of the DefaultQubit device.

A lot of fixes are thus necessary, with plenty of refactorings done as well.